### PR TITLE
Use symbols for polymorphic route arguments in Scope Type admin

### DIFF
--- a/OVERRIDES.md
+++ b/OVERRIDES.md
@@ -1,0 +1,3 @@
+## Overriden files
+- app/views/decidim/admin/scope_types/index.html.erb  
+(from https://github.com/decidim/decidim/blob/c91df0b7936982f2b8db6370aaf8b05c1d52a08c/decidim-admin/app/views/decidim/admin/scope_types/index.html.erb)

--- a/app/views/decidim/admin/scope_types/index.html.erb
+++ b/app/views/decidim/admin/scope_types/index.html.erb
@@ -1,0 +1,42 @@
+<div class="card">
+  <div class="card-divider">
+    <% if allowed_to? :creste, :scope_type %>
+      <h2 class="card-title"><%= t "decidim.admin.titles.scope_types" %> <%= link_to t("actions.add", scope: "decidim.admin"), [:new, :scope_type], class: "button tiny button--title" %></h2>
+    <% end %>
+  </div>
+  <div class="card-section">
+    <div class="table-scroll">
+        <table class="table-list">
+        <thead>
+          <tr>
+            <th><%= t("models.scope_type.fields.name", scope: "decidim.admin") %></th>
+            <th><%= t("models.scope_type.fields.plural", scope: "decidim.admin") %></th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <% scope_types.each do |scope_type| %>
+            <tr>
+              <td>
+                <%= translated_attribute(scope_type.name) %>
+              </td>
+              <td>
+                <%= translated_attribute(scope_type.plural) %>
+              </td>
+              <td class="table-list__actions">
+
+                <% if allowed_to? :update, :scope_type, scope_type: scope_type %>
+                  <%= icon_link_to "pencil", [:edit, scope_type], t("actions.edit", scope: "decidim.admin"), class: "action-icon--edit", method: :get, data: {} %>
+                <% end %>
+
+                <% if allowed_to? :destroy, :scope_type, scope_type: scope_type %>
+                  <%= icon_link_to "circle-x", scope_type, t("actions.destroy", scope: "decidim.admin"), class: "action-icon--remove", method: :delete, data: { confirm: t("actions.confirm_destroy", scope: "decidim.admin") } %>
+                <% end %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
This a temporary fix for the error
```
ActionView::Template::Error (Please use symbols for polymorphic route arguments.)
```
encountered when visiting the `/admin/scope_types` section of a Decidim 0.26.6 platform.

**⚠️ This fix should be revert when upgrading to decidim 0.24.2+ or a future 0.26.x version that contains it.**

Related issues & PR : 
- https://github.com/decidim/decidim/issues/8021
- https://github.com/decidim/decidim/pull/8052
- https://github.com/decidim/decidim/pull/7950
- https://github.com/decidim/decidim/pull/7946

### Complete Stacktrace : 
[log_scope_types.txt](https://github.com/antibes-dev/decidim-antibes/files/6676871/log_scope_types.txt)
